### PR TITLE
Use version glob for version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-pip_version: "1.5.4-1"
+pip_version: "1.5.*"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "azavea.pip" }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing pip.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
This change uses a glob for the minor version of the `pip` package to be installed.
