### PR TITLE
Update pip install method

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-pip_version: "1.5.*"
+pip_version: "9.0.*"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,10 +1,13 @@
 ---
-ansible:
-  verbose:
-  sudo: True
-  group_vars:
-    all:
-      - pip_version: "*"
+molecule:
+  test:
+    sequence:
+      - destroy
+      - syntax
+      - create
+      - converge
+      - idempotence
+      - verify
 
 vagrant:
   platforms:

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,6 +11,7 @@
     - name: Check Ubuntu release
       raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
       register: ubuntu_release
+      changed_when: false
 
     - debug: msg="Running Ubuntu version {{ ubuntu_release.stdout|float }}"
 
@@ -20,10 +21,12 @@
     - name: Update APT cache
       raw: apt-get update
       become: True
+      changed_when: false
 
     - name: Install python
       raw: apt-get install -yq python
       become: True
+      changed_when: false
       when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"
 
     # Gather facts once ansible dependencies are installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,19 @@
 ---
+- name: Get installed pip version
+  command: pip --version
+  register: pip_version_output
+  ignore_errors: yes
+  changed_when: false
+
+- name: Download get-pip.py
+  get_url: url=https://bootstrap.pypa.io/get-pip.py
+           dest=/tmp/get-pip.py
+
+# Install pip if it's not already installed, or if
+# the desired versions of pip aren't installed
+# The regular expression extracts '9.0' out of '9.0.*'
 - name: Install pip
-  apt: pkg=python-pip={{ pip_version }} state=present
+  command: "python get-pip.py pip=={{ pip_version }}"
+  when:  pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
+  args:
+    chdir: /tmp


### PR DESCRIPTION
Install `pip` using the `get-pip.py` installation script, rather than installing using APT. 

Closes #4  