### PR TITLE
Prevent get-pip.py download when unneeded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
 - name: Download get-pip.py
   get_url: url=https://bootstrap.pypa.io/get-pip.py
            dest=/tmp/get-pip.py
+  when: pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
 
 # Install pip if it's not already installed, or if
 # the desired versions of pip aren't installed


### PR DESCRIPTION
As the download location (/tmp) is deleted uppon reboots (on most linux
distributions) the role was not fully indempotent as get-pip.py was
downloaded each time even when not required.