### PR TITLE
Add support for older get-pip.py releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [pip](https://pip.pypa.io/en/latest/).
 ## Role Variables
 
 - `pip_version` - pip version
+- `pip_get_pip_version` - get_pip.py version
 
 ## Testing
 Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_pip.py](./tests/test_scala.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 pip_version: "9.0.*"
+pip_get_pip_version: "latest"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   changed_when: false
 
 - name: Download get-pip.py
-  get_url: url=https://bootstrap.pypa.io/get-pip.py
+  get_url: url=https://bootstrap.pypa.io/{{ (pip_get_pip_version == 'latest') | ternary('', pip_get_pip_version) }}/get-pip.py
            dest=/tmp/get-pip.py
   when: pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
 


### PR DESCRIPTION
## Overview

* Add `get_pip_version` variable
* Add conditional in `Download get-pip.py` task

Fixes #9 

## Testing Instructions

Apply this patch (until upstream fix https://github.com/pypa/get-pip/pull/38 gets merged):

```diff
diff --git a/defaults/main.yml b/defaults/main.yml
index d44b9a5..a6f6d80 100644
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 pip_version: "9.0.*"
-get_pip_version: "latest"
+get_pip_version: "3.3"
```

Ensure Ansible provisioning succeeds and Molecule tests pass:

```bash
$ pip install molecule==1.*
$ pip install ansible==2.3.*
$ molecule test
...
--> Starting Ansible Run...

PLAY [all] *********************************************************************

TASK [Check Ubuntu release] ****************************************************
ok: [ansible-pip]

TASK [debug] *******************************************************************
ok: [ansible-pip] => {
    "msg": "Running Ubuntu version 14.04"
}

TASK [Update APT cache] ********************************************************
ok: [ansible-pip]

TASK [Install python] **********************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ ubuntu_release.stdout|
version_compare('16.04', '>=') }}

skipping: [ansible-pip]

TASK [Gather facts] ************************************************************
ok: [ansible-pip]

TASK [ansible-pip : Get installed pip version] *********************************
fatal: [ansible-pip]: FAILED! => {"changed": false, "cmd": "pip --version", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}
...ignoring

TASK [ansible-pip : Download get-pip.py] ***************************************
changed: [ansible-pip]

TASK [ansible-pip : Install pip] ***********************************************
changed: [ansible-pip]

PLAY RECAP *********************************************************************
ansible-pip                : ok=7    changed=2    unreachable=0    failed=0

--> Idempotence test in progress (can take a few minutes)...
--> Starting Ansible Run...
Idempotence test passed.
--> Executing ansible-lint...
--> Executing flake8 on *.py files found in tests/...
--> Executing testinfra tests found in tests/...
============================= test session starts ==============================
platform darwin -- Python 2.7.15, pytest-3.5.1, py-1.5.3, pluggy-0.6.0
rootdir: /Users/rbreslow/Projects/ansible-pip, inifile:
plugins: testinfra-1.7.1
collected 1 item

tests/test_pip.py .                                                      [100%]

=============================== warnings summary ===============================
None
  Module already imported so cannot be rewritten: testinfra
  Ansible fixture is deprecated. Use host fixture and get Ansible module with host.ansible
  Command fixture is deprecated. Use host fixture instead
  TestinfraBackend fixture is deprecated. Use host fixture and get backend with host.backend

-- Docs: http://doc.pytest.org/en/latest/warnings.html
===================== 1 passed, 4 warnings in 0.87 seconds =====================
--> Destroying instances...
...
```

