### PR TITLE
Use absolute path to python interpreter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 # the desired versions of pip aren't installed
 # The regular expression extracts '9.0' out of '9.0.*'
 - name: Install pip
-  command: "python get-pip.py pip=={{ pip_version }}"
+  command: "{{ ansible_python_interpreter }} get-pip.py pip=={{ pip_version }}"
   when:  pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
   args:
     chdir: /tmp


### PR DESCRIPTION
Use `ansible_python_interpreter` to determine which Python executable should be used to install `pip`. This is particularly useful on clean installs of ubuntu 16.04, which doesn't include `/usr/bin/python`, but instead uses `/usr/bin/python3`. 

# Testing
See raster-foundry/raster-foundry#4274