### PR TITLE
Better filtering for installed pip version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,6 @@
 # The regular expression extracts '9.0' out of '9.0.*'
 - name: Install pip
   command: "python get-pip.py pip=={{ pip_version }}"
-  when:  pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
+  when:  pip_version_output | failed or not pip_version_output.stdout | search('pip ' + pip_version)
   args:
     chdir: /tmp


### PR DESCRIPTION
## Overview

When checking the currently installed pip version, instead of searching for the version string directly, search for `'pip ' + pip_version` in order to avoid the case where double-digit major versions accidentally match (e.g. `9.0.1` matches `19.0.1`).

Closes #12.

## Notes

This solution works because `pip --version` outputs a string like:

```
pip 19.0.1 from /usr/local/lib/python2.7/dist-packages/pip (python 2.7)
```

## Testing instructions

### Test version mismatch

* Clone the test repo I created:

```
# Use --recursive to download submodule reference to this branch
git clone --recursive https://github.com/jeancochrane/test-ansible-pip
```

* In `test-ansible-pip`, run `vagrant up` and confirm that provisioning works
    * The test repo copies the setup from https://github.com/azavea/pfb-network-connectivity (VM installation of pip `19.0.1` but Ansible requires `9.0.*`, and so should suffer the same problem as https://github.com/azavea/pfb-network-connectivity/issues/685
* Shell into the VM with `vagrant ssh`
* Run `pip --version` and confirm that the VM has installed `9.0.3`

### Test version match

* In `test-ansible-pip`, run `vagrant destroy -f` to clean out your VM
* Edit `site.yml` to change `pip_version` from `9.0.*` to `19.0.*`
* Run `vagrant up` and confirm that provisioning fails on the `[ Install docker-compose ]` step, as in https://github.com/azavea/pfb-network-connectivity/issues/685
* In the Ansible output, confirm that on step `[ azavea.pip: Install pip ]` Ansible did not try to reinstall pip because the versions matched:

```
TASK [azavea.pip : Install pip] ************************************************
skipping: [default] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}
```