### PR TITLE
Removed deprecated tests-as-filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An Ansible role for installing [pip](https://pip.pypa.io/en/latest/).
 
 - `pip_version` - pip version
 - `pip_get_pip_version` - get_pip.py version
+- `pip_executable` -  the executable to run to check pip's version
 
 ## Testing
 Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_pip.py](./tests/test_scala.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 pip_version: "9.0.*"
 pip_get_pip_version: "latest"
+pip_executable: "pip"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing pip.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.8
+  min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,25 @@
 ---
 - name: Get installed pip version
-  command: pip --version
+  command: "{{ pip_executable }} --version"
   register: pip_version_output
   ignore_errors: yes
   changed_when: false
 
 - name: Download get-pip.py
-  get_url: url=https://bootstrap.pypa.io/{{ (pip_get_pip_version == 'latest') | ternary('', pip_get_pip_version) }}/get-pip.py
-           dest=/tmp/get-pip.py
-  when: pip_version_output | failed or not pip_version_output.stdout | search(pip_version)
+  vars:
+      pip_version_url: "{{ (pip_get_pip_version == 'latest') | ternary('', pip_get_pip_version) }}"
+      required_vars:
+          - pip_get_pip_version
+  get_url:
+      url: 'https://bootstrap.pypa.io/{{ pip_version_url }}/get-pip.py'
+      dest: /tmp/get-pip.py
+  when: (pip_version_output is failed) or not pip_version_output.stdout is search(pip_version)
 
 # Install pip if it's not already installed, or if
 # the desired versions of pip aren't installed
 # The regular expression extracts '9.0' out of '9.0.*'
 - name: Install pip
   command: "python get-pip.py pip=={{ pip_version }}"
-  when:  pip_version_output | failed or not pip_version_output.stdout | search('pip ' + pip_version)
+  when: "(pip_version_output is failed) or not pip_version_output.stdout is search('pip ' + pip_version)"
   args:
     chdir: /tmp


### PR DESCRIPTION
There were a few instances of `result | failed` (or similar) which I've
removed. I also factored out an extremely long line in the "Download
get-pip.py" line to a variable and added a 'pip_executable' variable
(even after pip was installed, a misconfigured PATH would make 'pip
--version' still fail).