### PR TITLE
Try to use ansible_python_interpreter instead of python

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
 # the desired versions of pip aren't installed
 # The regular expression extracts '9.0' out of '9.0.*'
 - name: Install pip
-  command: "python get-pip.py pip=={{ pip_version }}"
+  command: "{{ ansible_python_interpreter if ansible_python_interpreter is defined else 'python' }} get-pip.py pip=={{ pip_version }}"
   when: "(pip_version_output is failed) or not pip_version_output.stdout is search('pip ' + pip_version)"
   args:
     chdir: /tmp


### PR DESCRIPTION
## Overview

Try to use the `ansible_python_interpreter` variable instead of invoking `python` directly.

This is to add support for Python 3.

## Testing Instructions

Make sure `molecule` tests pass:

```bash
$ virtualenv .
$ source ./env/bin/activate
$ pip install molecule==1.25.1
$ pip install python-vagrant
$ molecule test
```