### PR TITLE
Fixed linter-error: [E702] Use 'galaxy_tags' rather than 'categories'

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,6 @@ galaxy_info:
     versions:
     - trusty
     - xenial
-  categories:
+  galaxy_tags:
   - development
 dependencies: []


### PR DESCRIPTION
This PR fixes an Ansible-lint error:
[E702] Use 'galaxy_tags' rather than 'categories'