### PR TITLE
Update get-pip URL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
       required_vars:
           - pip_get_pip_version
   get_url:
-      url: 'https://bootstrap.pypa.io/{{ pip_version_url }}/get-pip.py'
+      url: 'https://bootstrap.pypa.io/pip/{{ pip_version_url }}/get-pip.py'
       dest: /tmp/get-pip.py
   when: (pip_version_output is failed) or not pip_version_output.stdout is search(pip_version)
 


### PR DESCRIPTION
It was changed recently, breaking everything.

Getting this error message instead:

```

Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
```